### PR TITLE
Give option to disable Nunjucks when processing posts.

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -234,6 +234,7 @@ Post.prototype.render = function(source, data, callback) {
 
   var ctx = this.context;
   var config = ctx.config;
+  var disableNunjucks = config.disable_nunjucks;
   var cache = [];
   var tag = ctx.extend.tag;
   var isSwig = data.engine === 'swig' || (source && pathFn.extname(source) === '.swig');
@@ -243,6 +244,7 @@ Post.prototype.render = function(source, data, callback) {
   }
 
   function tagFilter(content) {
+    if (disableNunjucks) return content;
     // Replace cache data with real contents
     content = content.replace(rPlaceholder, function() {
       return cache[arguments[1]];
@@ -272,12 +274,14 @@ Post.prototype.render = function(source, data, callback) {
     // Skip rendering if this is a swig file
     if (isSwig) return data.content;
 
-    // Escape all Swig tags
-    data.content = data.content
-      .replace(rSwigFullBlock, escapeContent)
-      .replace(rSwigBlock, escapeContent)
-      .replace(rSwigComment, '')
-      .replace(rSwigVar, escapeContent);
+    if (!disableNunjucks) {
+      // Escape all Swig tags
+      data.content = data.content
+        .replace(rSwigFullBlock, escapeContent)
+        .replace(rSwigBlock, escapeContent)
+        .replace(rSwigComment, '')
+        .replace(rSwigVar, escapeContent);
+    }
 
     var options = data.markdown || {};
     if (!config.highlight.enable) options.highlight = null;


### PR DESCRIPTION
This PR introduces:

- An option, `disable_nunjucks`, to disable Nunjucks when processing posts.
- The code that skips Nunjucks depending on this option.